### PR TITLE
Feat : 거래내역 및 예측 가격(최대 최소) , 아파트 위도 경도 전달 로직 구현

### DIFF
--- a/src/main/java/side/project/homepredictor/domain/apartmenttype/controller/ApartmentTypeController.java
+++ b/src/main/java/side/project/homepredictor/domain/apartmenttype/controller/ApartmentTypeController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 import side.project.homepredictor.domain.apartmenttype.service.ApartmentTypeService;
 
 @RestController
-@RequestMapping("/v1/apartmenttype")
+@RequestMapping("/v1/apartmenttypes")
 @RequiredArgsConstructor
 public class ApartmentTypeController {
     private final ApartmentTypeService apartmentTypeService;
@@ -20,6 +20,15 @@ public class ApartmentTypeController {
             .ok()
             .body(
                 apartmentTypeService.findApartmentTypeList(apartmentId)
+            );
+    }
+
+    @GetMapping("/locations/{apartmentId}")
+    public ResponseEntity<?> getApartmentLocation(@PathVariable Long apartmentId) {
+        return ResponseEntity
+            .ok()
+            .body(
+                apartmentTypeService.findApartmentLocation(apartmentId)
             );
     }
 }

--- a/src/main/java/side/project/homepredictor/domain/apartmenttype/dto/response/ApartmentTypeResponseDto.java
+++ b/src/main/java/side/project/homepredictor/domain/apartmenttype/dto/response/ApartmentTypeResponseDto.java
@@ -1,24 +1,63 @@
 package side.project.homepredictor.domain.apartmenttype.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import side.project.homepredictor.domain.apartment.entity.Apartment;
 import side.project.homepredictor.domain.apartmenttype.entity.ApartmentType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static java.lang.Math.max;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class ApartmentTypeResponseDto {
-    private Long apartmentId;
+    private Long apartmentTypeId;
     private Integer size;
-    private Long predictedPrice;
+    private Long predictedPrice1;
+    private Long predictedPrice2;
+    private Long predictedPrice3;
+    private Max highestPredictedPrice;
+    private Min lowestPredictedPrice;
 
     public static ApartmentTypeResponseDto fromEntity(ApartmentType apartmentType) {
+        Result result = getResult(apartmentType);
         return ApartmentTypeResponseDto.builder()
-            .apartmentId(apartmentType.getApartment().getId())
+            .apartmentTypeId(apartmentType.getId())
             .size(apartmentType.getSize())
-            .predictedPrice(apartmentType.getPredictedPrice())
+            .predictedPrice1(apartmentType.getPredictedPrice1())
+            .predictedPrice2(apartmentType.getPredictedPrice2())
+            .predictedPrice3(apartmentType.getPredictedPrice3())
+            .highestPredictedPrice(new Max(result.highDate(), result.high()))
+            .lowestPredictedPrice(new Min(result.lowDate(), result.low()))
             .build();
     }
+
+    private static Result getResult(ApartmentType apartmentType) {
+        List<Long> predictedPriceList = List.of(
+            apartmentType.getPredictedPrice1(),
+            apartmentType.getPredictedPrice2(),
+            apartmentType.getPredictedPrice3()
+        );
+
+        Long high = Collections.max(predictedPriceList);
+        int highDate = predictedPriceList.indexOf(high) + 1;
+
+        Long low = Collections.min(predictedPriceList);
+        int lowDate = predictedPriceList.indexOf(low) + 1;
+
+        return new Result(high, highDate, low, lowDate);
+    }
+
+    private record Result(Long high, int highDate, Long low, int lowDate) {
+    }
 }
+record Max(int date,Long price) {}
+
+record Min(int date,Long price) {}

--- a/src/main/java/side/project/homepredictor/domain/apartmenttype/dto/response/LocationDto.java
+++ b/src/main/java/side/project/homepredictor/domain/apartmenttype/dto/response/LocationDto.java
@@ -1,0 +1,22 @@
+package side.project.homepredictor.domain.apartmenttype.dto.response;
+
+import lombok.*;
+import side.project.homepredictor.domain.apartment.entity.Apartment;
+import side.project.homepredictor.domain.apartmenttype.entity.ApartmentType;
+import side.project.homepredictor.domain.dealhistory.dto.DealHistoryResponseDto;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LocationDto {
+    private Double latitude;
+    private Double longitude;
+
+    public static LocationDto fromEntity(Apartment apartment) {
+        return LocationDto.builder()
+            .latitude(apartment.getLatitude())
+            .longitude(apartment.getLongitude())
+            .build();
+    }
+}

--- a/src/main/java/side/project/homepredictor/domain/apartmenttype/entity/ApartmentType.java
+++ b/src/main/java/side/project/homepredictor/domain/apartmenttype/entity/ApartmentType.java
@@ -1,17 +1,16 @@
 package side.project.homepredictor.domain.apartmenttype.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import side.project.homepredictor.domain.apartment.entity.Apartment;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Getter
 @AllArgsConstructor
@@ -27,5 +26,13 @@ public class ApartmentType {
     @JoinColumn(name = "apartment_id")
     private Apartment apartment;
     private Integer size;
-    private Long predictedPrice;
+    private Long predictedPrice1;
+    private Long predictedPrice2;
+    private Long predictedPrice3;
+    @Transient
+    private Map<String, Double> dealHistoryMap = new HashMap<>();
+
+    public void updateDealHistory(Map<String, Double> map) {
+        this.dealHistoryMap = map;
+    }
 }

--- a/src/main/java/side/project/homepredictor/domain/apartmenttype/repository/ApartmentTypeRepository.java
+++ b/src/main/java/side/project/homepredictor/domain/apartmenttype/repository/ApartmentTypeRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface ApartmentTypeRepository extends JpaRepository<ApartmentType,Long> {
 
     List<ApartmentType> findAllByApartment(Apartment apartment);
+
+    List<ApartmentType> findAllById(Long id);
 }

--- a/src/main/java/side/project/homepredictor/domain/apartmenttype/service/ApartmentTypeService.java
+++ b/src/main/java/side/project/homepredictor/domain/apartmenttype/service/ApartmentTypeService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import side.project.homepredictor.domain.apartment.entity.Apartment;
 import side.project.homepredictor.domain.apartment.repository.ApartmentRepository;
 import side.project.homepredictor.domain.apartmenttype.dto.response.ApartmentTypeResponseDto;
+import side.project.homepredictor.domain.apartmenttype.dto.response.LocationDto;
 import side.project.homepredictor.domain.apartmenttype.repository.ApartmentTypeRepository;
 
 import java.util.List;
@@ -24,5 +25,12 @@ public class ApartmentTypeService {
             .stream()
             .map(ApartmentTypeResponseDto::fromEntity)
             .collect(Collectors.toList());
+    }
+
+    public LocationDto findApartmentLocation(Long apartmentId) {
+        Apartment apartment = apartmentRepository.findById(apartmentId).orElseThrow(
+            IllegalArgumentException::new
+        );
+        return LocationDto.fromEntity(apartment);
     }
 }

--- a/src/main/java/side/project/homepredictor/domain/dealhistory/controller/DealHistoryController.java
+++ b/src/main/java/side/project/homepredictor/domain/dealhistory/controller/DealHistoryController.java
@@ -1,0 +1,25 @@
+package side.project.homepredictor.domain.dealhistory.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import side.project.homepredictor.domain.dealhistory.service.DealHistoryService;
+
+@RestController
+@RequestMapping("/v1/dealhistories")
+@RequiredArgsConstructor
+public class DealHistoryController {
+    private final DealHistoryService dealHistoryService;
+
+    @GetMapping("/{apartmentTypeId}")
+    public ResponseEntity<?> getDealHistory(@PathVariable Long apartmentTypeId) {
+        return ResponseEntity
+            .ok()
+            .body(
+                dealHistoryService.findDealHistory(apartmentTypeId)
+            );
+    }
+}

--- a/src/main/java/side/project/homepredictor/domain/dealhistory/dto/DealHistoryResponseDto.java
+++ b/src/main/java/side/project/homepredictor/domain/dealhistory/dto/DealHistoryResponseDto.java
@@ -1,0 +1,20 @@
+package side.project.homepredictor.domain.dealhistory.dto;
+
+import lombok.*;
+import side.project.homepredictor.domain.apartmenttype.entity.ApartmentType;
+
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DealHistoryResponseDto {
+    private Map<String, Double> dealHistoryMap;
+
+    public static DealHistoryResponseDto fromEntity(ApartmentType apartmentType) {
+        return DealHistoryResponseDto.builder()
+            .dealHistoryMap(apartmentType.getDealHistoryMap())
+            .build();
+    }
+}

--- a/src/main/java/side/project/homepredictor/domain/dealhistory/repository/DealHistoryRepository.java
+++ b/src/main/java/side/project/homepredictor/domain/dealhistory/repository/DealHistoryRepository.java
@@ -1,0 +1,12 @@
+package side.project.homepredictor.domain.dealhistory.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import side.project.homepredictor.domain.apartmenttype.entity.ApartmentType;
+import side.project.homepredictor.domain.dealhistory.entity.DealHistory;
+
+import java.util.List;
+
+public interface DealHistoryRepository extends JpaRepository<DealHistory,Long> {
+
+    List<DealHistory> findAllByApartmentTypeOrderByDealDate(ApartmentType apartmentType);
+}

--- a/src/main/java/side/project/homepredictor/domain/dealhistory/service/DealHistoryService.java
+++ b/src/main/java/side/project/homepredictor/domain/dealhistory/service/DealHistoryService.java
@@ -1,0 +1,34 @@
+package side.project.homepredictor.domain.dealhistory.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import side.project.homepredictor.domain.apartmenttype.dto.response.ApartmentTypeResponseDto;
+import side.project.homepredictor.domain.apartmenttype.entity.ApartmentType;
+import side.project.homepredictor.domain.apartmenttype.repository.ApartmentTypeRepository;
+import side.project.homepredictor.domain.dealhistory.dto.DealHistoryResponseDto;
+import side.project.homepredictor.domain.dealhistory.entity.DealHistory;
+import side.project.homepredictor.domain.dealhistory.repository.DealHistoryRepository;
+
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class DealHistoryService {
+    private final DealHistoryRepository dealHistoryRepository;
+    private final ApartmentTypeRepository apartmentTypeRepository;
+
+    public DealHistoryResponseDto findDealHistory(Long apartmentTypeId) {
+        ApartmentType apartmentType = apartmentTypeRepository.getReferenceById(apartmentTypeId);
+        List<DealHistory> dealHistoryList = dealHistoryRepository.findAllByApartmentTypeOrderByDealDate(apartmentType);
+        Map<String, Double> monthAvrgDealHistoryMap = dealHistoryList.stream()
+            .collect(Collectors.groupingBy(
+                dealHistory -> YearMonth.from(dealHistory.getDealDate()).toString(),
+                Collectors.averagingDouble(DealHistory::getDealPrice)
+            ));
+        apartmentType.updateDealHistory(monthAvrgDealHistoryMap);
+        return DealHistoryResponseDto.fromEntity(apartmentType);
+    }
+}


### PR DESCRIPTION
- 거래내역 api 별도 분리 (dealhistory 도메인 내 개발)
- 1,2,3개월 예측 가격 응답 칼럼으로 추가. 현재 기준 몇개월 뒤가 최대,최소인지 구분하는 로직 추가
- 아파트id 기준으로 위도 경도 전달하는 api 별도 생성